### PR TITLE
feat: enable iOS status bar styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>MinuTrenn</title>
   <meta name="description" content="Personaal- ja rühmatreeningud. Kaasaegne PWA veebirakendus." />
   <meta name="theme-color" content="#000000" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="manifest" href="manifest.json" />
   <link rel="icon" href="img/icon-192.png" />
   <link rel="apple-touch-icon" href="img/icon-192.png" />


### PR DESCRIPTION
## Summary
- add meta tag to allow standalone iOS web app capabilities
- specify iOS status bar style as black-translucent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8aa9da288330b0ca9e320b1f35d4