### PR TITLE
feat: update brand colors to blue

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3,7 +3,7 @@
   --bg: #ffffff;
   --fg: #222;
   --muted: #666;
-  --brand: #ff6600;
+  --brand: #0076ff;
   --brand-ink: #ffffff;
   --card: #f6f6f6;
 }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MinuTrenn</title>
   <meta name="description" content="Personaal- ja rühmatreeningud. Kaasaegne PWA veebirakendus." />
-  <meta name="theme-color" content="#000000" />
+  <meta name="theme-color" content="#0076ff" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <link rel="manifest" href="manifest.json" />

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "start_url": ".",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#000000",
+  "theme_color": "#0076ff",
   "icons": [
     { "src": "img/icon-192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "img/icon-512.png", "sizes": "512x512", "type": "image/png" }


### PR DESCRIPTION
## Summary
- switch theme and manifest colors to blue
- align CSS brand variable with new accent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8b10e4d083309bb6437eda7a8609