### PR TITLE
Add preloader spinner to display while page loads

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,30 @@ body {
   line-height: 1.6;
 }
 
+/* Preloader */
+#preloader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  z-index: 9999;
+}
+
+#preloader .spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid var(--brand);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Header / Nav */
 .site-header { position: sticky; top: 0; z-index: 50; backdrop-filter: blur(6px); background: rgba(255,255,255,0.8); border-bottom: 1px solid #eee; }
 .nav { display: flex; align-items: center; justify-content: space-between; max-width: 1100px; margin: 0 auto; padding: 12px 16px; }

--- a/index.html
+++ b/index.html
@@ -15,6 +15,9 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
+  <div id="preloader">
+    <div class="spinner"></div>
+  </div>
   <header class="site-header">
     <nav class="nav">
       <div class="logo">MinuTrenn</div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,14 @@
-// Register Service Worker (relative path for GitHub Pages subpaths)
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
+// Remove preloader and register Service Worker when page loads
+window.addEventListener('load', () => {
+  const preloader = document.getElementById('preloader');
+  if (preloader) preloader.remove();
+
+  if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('service-worker.js', { scope: './' })
       .then(() => console.log('Service Worker registered'))
       .catch(err => console.error('SW registration failed:', err));
-  });
-}
+  }
+});
 
 // Smooth anchor scroll
 document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Add preloader container with spinner at top of body
- Style full-screen centered spinner overlay
- Remove preloader on page load and register service worker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8c7a087c8330a804650f7fb327fb