### PR TITLE
Add secondary hero CTA and button variants

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,8 +79,13 @@ body {
 .hero .hero-inner { max-width: 900px; }
 .hero h1 { font-size: clamp(28px, 6vw, 56px); margin: 0 0 12px; }
 .hero p { font-size: clamp(16px, 2.2vw, 22px); margin: 0 0 20px; color: #f0f0f0; }
-.btn { background: var(--brand); color: var(--brand-ink); padding: 12px 20px; border-radius: 10px; text-decoration: none; display: inline-block; font-weight: 700; border: 0; cursor: pointer; }
-.btn:hover { filter: brightness(0.95); }
+.hero-ctas { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+.btn { padding: 12px 20px; border-radius: 10px; text-decoration: none; display: inline-block; font-weight: 700; border: 0; cursor: pointer; }
+.btn:focus-visible { outline: 3px solid var(--brand); outline-offset: 2px; }
+.btn-primary { background: var(--brand); color: var(--brand-ink); }
+.btn-primary:hover { filter: brightness(0.95); }
+.btn-secondary { background: transparent; color: var(--brand); border: 2px solid var(--brand); }
+.btn-secondary:hover { background: var(--brand); color: var(--brand-ink); }
 
 .btn .material-icons-round {
   font-size: 20px;

--- a/index.html
+++ b/index.html
@@ -38,7 +38,10 @@
       <div class="hero-inner">
         <h1>Tere tulemast MinuTrenn!</h1>
         <p>Liigu targalt. Tunneta edusamme. Püsi motiveeritud.</p>
-        <a class="btn" href="#contact">Võta ühendust</a>
+        <div class="hero-ctas" role="group" aria-label="Peamised tegevused">
+          <a class="btn btn-primary" href="#contact">Võta ühendust</a>
+          <a class="btn btn-secondary" href="#services">Vaata treeninguid</a>
+        </div>
       </div>
     </section>
 
@@ -73,7 +76,7 @@
           <input type="email" name="email" placeholder="E-post" required />
         </div>
         <textarea name="message" placeholder="Sõnum" rows="5"></textarea>
-        <button type="submit" class="btn"><span class="material-icons-round" aria-hidden="true">send</span>Saada</button>
+        <button type="submit" class="btn btn-primary"><span class="material-icons-round" aria-hidden="true">send</span>Saada</button>
       </form>
       <p class="note">Näidisvorm: asenda <code>your_form_id</code> oma Formspree/Netlify Forms/Google Forms lahendusega.</p>
     </section>


### PR DESCRIPTION
## Summary
- add secondary "Vaata treeninguid" call-to-action in hero
- introduce primary and secondary button styles with visible focus outlines
- group hero CTAs for screen reader clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d412248833088e34e5cb1795cf3