### PR TITLE
Add training carousel with reusable card component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
   <SiteHeader />
   <main>
     <HeroSection />
+    <TrainingCarousel />
     <ServicesSection />
     <AboutSection />
     <ContactSection />
@@ -15,6 +16,7 @@
 <script setup>
 import SiteHeader from './components/SiteHeader.vue'
 import HeroSection from './components/HeroSection.vue'
+import TrainingCarousel from './components/TrainingCarousel.vue'
 import ServicesSection from './components/ServicesSection.vue'
 import AboutSection from './components/AboutSection.vue'
 import ContactSection from './components/ContactSection.vue'

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -117,3 +117,14 @@ body {
 @media (max-width: 640px) {
   .contact-form .row { grid-template-columns: 1fr; }
 }
+
+/* Training carousel */
+.training-carousel { position: relative; overflow: hidden; }
+.training-carousel .carousel-track { display: flex; transition: transform 0.4s ease; }
+.training-carousel .training-card { flex: 0 0 100%; }
+.carousel-arrow { position: absolute; top: 50%; transform: translateY(-50%); background: var(--brand); color: var(--brand-ink); border: none; border-radius: 50%; width: 44px; height: 44px; display: flex; align-items: center; justify-content: center; cursor: pointer; }
+.carousel-arrow.prev { left: 16px; }
+.carousel-arrow.next { right: 16px; }
+@media (max-width: 640px) {
+  .carousel-arrow { width: 36px; height: 36px; }
+}

--- a/src/components/TrainingCard.vue
+++ b/src/components/TrainingCard.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="card training-card">
+    <h3>{{ training.title }}</h3>
+    <p>{{ training.description }}</p>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  training: {
+    type: Object,
+    required: true
+  }
+})
+</script>

--- a/src/components/TrainingCarousel.vue
+++ b/src/components/TrainingCarousel.vue
@@ -1,0 +1,37 @@
+<template>
+  <section class="section">
+    <div class="training-carousel">
+      <button class="carousel-arrow prev" @click="prev" aria-label="Eelmine treening">
+        <span class="material-icons-round">chevron_left</span>
+      </button>
+      <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
+        <TrainingCard v-for="(t, i) in trainings" :key="i" :training="t" />
+      </div>
+      <button class="carousel-arrow next" @click="next" aria-label="Järgmine treening">
+        <span class="material-icons-round">chevron_right</span>
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import TrainingCard from './TrainingCard.vue'
+
+const trainings = [
+  { title: 'Jõutreening', description: 'Paranda lihasjõudu ja vastupidavust.' },
+  { title: 'Jooga', description: 'Tugevdab keha ja meelt.' },
+  { title: 'Kardio', description: 'Tõstab pulssi ja põletab kaloreid.' }
+]
+
+const currentIndex = ref(0)
+const total = trainings.length
+
+function next() {
+  currentIndex.value = (currentIndex.value + 1) % total
+}
+
+function prev() {
+  currentIndex.value = (currentIndex.value - 1 + total) % total
+}
+</script>


### PR DESCRIPTION
## Summary
- add `TrainingCard` and `TrainingCarousel` components for a horizontal training slider
- insert the carousel into the main layout after the hero section
- style carousel container and navigation arrows for responsive behaviour

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd9fe6880483309167bba5cb6e9416