### PR TITLE
Add placeholder carousel for other trainings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
   <main>
     <HeroSection />
     <TrainingCarousel />
+    <OtherTrainingCarousel />
     <ServicesSection />
     <AboutSection />
     <ContactSection />
@@ -17,6 +18,7 @@
 import SiteHeader from './components/SiteHeader.vue'
 import HeroSection from './components/HeroSection.vue'
 import TrainingCarousel from './components/TrainingCarousel.vue'
+import OtherTrainingCarousel from './components/OtherTrainingCarousel.vue'
 import ServicesSection from './components/ServicesSection.vue'
 import AboutSection from './components/AboutSection.vue'
 import ContactSection from './components/ContactSection.vue'

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -118,10 +118,13 @@ body {
   .contact-form .row { grid-template-columns: 1fr; }
 }
 
-/* Training carousel */
-.training-carousel { position: relative; overflow: hidden; }
-.training-carousel .carousel-track { display: flex; transition: transform 0.4s ease; }
-.training-carousel .training-card { flex: 0 0 100%; }
+/* Carousel */
+.training-carousel,
+.other-training-carousel { position: relative; overflow: hidden; }
+.training-carousel .carousel-track,
+.other-training-carousel .carousel-track { display: flex; transition: transform 0.4s ease; }
+.training-carousel .training-card,
+.other-training-carousel .training-card { flex: 0 0 100%; }
 .carousel-arrow { position: absolute; top: 50%; transform: translateY(-50%); background: var(--brand); color: var(--brand-ink); border: none; border-radius: 50%; width: 44px; height: 44px; display: flex; align-items: center; justify-content: center; cursor: pointer; }
 .carousel-arrow.prev { left: 16px; }
 .carousel-arrow.next { right: 16px; }

--- a/src/components/OtherTrainingCarousel.vue
+++ b/src/components/OtherTrainingCarousel.vue
@@ -1,0 +1,34 @@
+<template>
+  <section class="section">
+    <div class="training-carousel">
+      <button class="carousel-arrow prev" @click="prev" aria-label="Eelmine treening">
+        <span class="material-icons-round">chevron_left</span>
+      </button>
+      <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
+        <TrainingCard v-for="(t, i) in trainings" :key="i" :training="t" />
+      </div>
+      <button class="carousel-arrow next" @click="next" aria-label="Järgmine treening">
+        <span class="material-icons-round">chevron_right</span>
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import TrainingCard from './TrainingCard.vue'
+
+const trainings = []
+const currentIndex = ref(0)
+const total = trainings.length
+
+function next() {
+  if (!total) return
+  currentIndex.value = (currentIndex.value + 1) % total
+}
+
+function prev() {
+  if (!total) return
+  currentIndex.value = (currentIndex.value - 1 + total) % total
+}
+</script>


### PR DESCRIPTION
## Summary
- add `OtherTrainingCarousel` component scaffold
- show additional carousel in `App.vue`
- share carousel styles across components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bda336857483309c9b7294d3ef4068