### PR TITLE
Add nutrition video carousel component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@
     <HeroSection />
     <TrainingCarousel />
     <OtherTrainingCarousel />
+    <NutritionVideosCarousel />
     <ServicesSection />
     <AboutSection />
     <ContactSection />
@@ -19,6 +20,7 @@ import SiteHeader from './components/SiteHeader.vue'
 import HeroSection from './components/HeroSection.vue'
 import TrainingCarousel from './components/TrainingCarousel.vue'
 import OtherTrainingCarousel from './components/OtherTrainingCarousel.vue'
+import NutritionVideosCarousel from './components/NutritionVideosCarousel.vue'
 import ServicesSection from './components/ServicesSection.vue'
 import AboutSection from './components/AboutSection.vue'
 import ContactSection from './components/ContactSection.vue'

--- a/src/components/NutritionVideosCarousel.vue
+++ b/src/components/NutritionVideosCarousel.vue
@@ -1,0 +1,46 @@
+<template>
+  <section class="section">
+    <div class="card">
+      <div class="nutrition-videos-carousel">
+        <button class="carousel-arrow prev" @click="prev" aria-label="Eelmine video">
+          <span class="material-icons-round">chevron_left</span>
+        </button>
+        <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
+          <div v-for="(v, i) in videos" :key="i" class="video-slot">
+            <!-- Video player will be inserted here -->
+          </div>
+        </div>
+        <button class="carousel-arrow next" @click="next" aria-label="Järgmine video">
+          <span class="material-icons-round">chevron_right</span>
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const videos = []
+const currentIndex = ref(0)
+const total = videos.length
+
+function next() {
+  if (!total) return
+  currentIndex.value = (currentIndex.value + 1) % total
+}
+
+function prev() {
+  if (!total) return
+  currentIndex.value = (currentIndex.value - 1 + total) % total
+}
+</script>
+
+<style scoped>
+.nutrition-videos-carousel { position: relative; overflow: hidden; }
+.nutrition-videos-carousel .carousel-track { display: flex; transition: transform 0.4s ease; }
+.nutrition-videos-carousel .video-slot { flex: 0 0 100%; display: flex; justify-content: center; align-items: center; }
+.nutrition-videos-carousel iframe,
+.nutrition-videos-carousel video { max-width: 100%; border-radius: 10px; }
+</style>
+


### PR DESCRIPTION
## Summary
- add placeholder `NutritionVideosCarousel` component with card wrapper and empty carousel for future video players
- include the nutrition videos carousel in the home page below the other trainings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bda4d321d48330803c1801da0498ea