### PR TITLE
feat: add accessible header menu toggle

### DIFF
--- a/src/components/SiteHeader.vue
+++ b/src/components/SiteHeader.vue
@@ -1,9 +1,14 @@
 <template>
   <header class="site-header">
-    <nav class="nav">
+    <nav class="nav" :aria-expanded="isMenuOpen">
       <div class="logo">MinuTrenn</div>
-      <input id="menu-toggle" type="checkbox" />
-      <label class="menu-button-container" for="menu-toggle">
+      <input id="menu-toggle" type="checkbox" v-model="isMenuOpen" />
+      <label
+        class="menu-button-container"
+        for="menu-toggle"
+        aria-label="Ava menüü"
+        :aria-expanded="isMenuOpen"
+      >
         <div class="menu-button"></div>
       </label>
       <ul class="menu">
@@ -16,4 +21,7 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
+
+const isMenuOpen = ref(false)
 </script>


### PR DESCRIPTION
## Summary
- add aria-label and aria-expanded to mobile menu toggle
- manage open state with Vue ref to keep aria-expanded in sync

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bda6c08dfc83309763f850698b02c7