### PR TITLE
feat: add reusable carousel component

### DIFF
--- a/src/components/Carousel.vue
+++ b/src/components/Carousel.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="carousel">
+    <button class="carousel-arrow prev" @click="prev" aria-label="Previous">
+      <span class="material-icons-round">chevron_left</span>
+    </button>
+    <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
+      <div v-for="(item, i) in items" :key="i" class="carousel-item">
+        <slot :item="item" :index="i" />
+      </div>
+    </div>
+    <button class="carousel-arrow next" @click="next" aria-label="Next">
+      <span class="material-icons-round">chevron_right</span>
+    </button>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  items: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const currentIndex = ref(0)
+const total = computed(() => props.items.length)
+
+function next() {
+  if (!total.value) return
+  currentIndex.value = (currentIndex.value + 1) % total.value
+}
+
+function prev() {
+  if (!total.value) return
+  currentIndex.value = (currentIndex.value - 1 + total.value) % total.value
+}
+</script>
+
+<style scoped>
+.carousel { position: relative; overflow: hidden; }
+.carousel-track { display: flex; transition: transform 0.4s ease; }
+.carousel-item { flex: 0 0 100%; }
+</style>

--- a/src/components/NutritionVideosCarousel.vue
+++ b/src/components/NutritionVideosCarousel.vue
@@ -1,46 +1,25 @@
 <template>
   <section class="section">
     <div class="card">
-      <div class="nutrition-videos-carousel">
-        <button class="carousel-arrow prev" @click="prev" aria-label="Eelmine video">
-          <span class="material-icons-round">chevron_left</span>
-        </button>
-        <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
-          <div v-for="(v, i) in videos" :key="i" class="video-slot">
+      <Carousel class="nutrition-videos-carousel" :items="videos">
+        <template #default="{ item }">
+          <div class="video-slot">
             <!-- Video player will be inserted here -->
           </div>
-        </div>
-        <button class="carousel-arrow next" @click="next" aria-label="Järgmine video">
-          <span class="material-icons-round">chevron_right</span>
-        </button>
-      </div>
+        </template>
+      </Carousel>
     </div>
   </section>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import Carousel from './Carousel.vue'
 
 const videos = []
-const currentIndex = ref(0)
-const total = videos.length
-
-function next() {
-  if (!total) return
-  currentIndex.value = (currentIndex.value + 1) % total
-}
-
-function prev() {
-  if (!total) return
-  currentIndex.value = (currentIndex.value - 1 + total) % total
-}
 </script>
 
 <style scoped>
-.nutrition-videos-carousel { position: relative; overflow: hidden; }
-.nutrition-videos-carousel .carousel-track { display: flex; transition: transform 0.4s ease; }
-.nutrition-videos-carousel .video-slot { flex: 0 0 100%; display: flex; justify-content: center; align-items: center; }
-.nutrition-videos-carousel iframe,
-.nutrition-videos-carousel video { max-width: 100%; border-radius: 10px; }
+.video-slot { flex: 0 0 100%; display: flex; justify-content: center; align-items: center; }
+iframe,
+video { max-width: 100%; border-radius: 10px; }
 </style>
-

--- a/src/components/OtherTrainingCarousel.vue
+++ b/src/components/OtherTrainingCarousel.vue
@@ -1,34 +1,16 @@
 <template>
   <section class="section">
-    <div class="training-carousel">
-      <button class="carousel-arrow prev" @click="prev" aria-label="Eelmine treening">
-        <span class="material-icons-round">chevron_left</span>
-      </button>
-      <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
-        <TrainingCard v-for="(t, i) in trainings" :key="i" :training="t" />
-      </div>
-      <button class="carousel-arrow next" @click="next" aria-label="Järgmine treening">
-        <span class="material-icons-round">chevron_right</span>
-      </button>
-    </div>
+    <Carousel class="other-training-carousel" :items="trainings">
+      <template #default="{ item }">
+        <TrainingCard :training="item" />
+      </template>
+    </Carousel>
   </section>
 </template>
 
 <script setup>
-import { ref } from 'vue'
 import TrainingCard from './TrainingCard.vue'
+import Carousel from './Carousel.vue'
 
 const trainings = []
-const currentIndex = ref(0)
-const total = trainings.length
-
-function next() {
-  if (!total) return
-  currentIndex.value = (currentIndex.value + 1) % total
-}
-
-function prev() {
-  if (!total) return
-  currentIndex.value = (currentIndex.value - 1 + total) % total
-}
 </script>

--- a/src/components/TrainingCarousel.vue
+++ b/src/components/TrainingCarousel.vue
@@ -1,37 +1,20 @@
 <template>
   <section class="section">
-    <div class="training-carousel">
-      <button class="carousel-arrow prev" @click="prev" aria-label="Eelmine treening">
-        <span class="material-icons-round">chevron_left</span>
-      </button>
-      <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
-        <TrainingCard v-for="(t, i) in trainings" :key="i" :training="t" />
-      </div>
-      <button class="carousel-arrow next" @click="next" aria-label="Järgmine treening">
-        <span class="material-icons-round">chevron_right</span>
-      </button>
-    </div>
+    <Carousel class="training-carousel" :items="trainings">
+      <template #default="{ item }">
+        <TrainingCard :training="item" />
+      </template>
+    </Carousel>
   </section>
 </template>
 
 <script setup>
-import { ref } from 'vue'
 import TrainingCard from './TrainingCard.vue'
+import Carousel from './Carousel.vue'
 
 const trainings = [
   { title: 'Jõutreening', description: 'Paranda lihasjõudu ja vastupidavust.' },
   { title: 'Jooga', description: 'Tugevdab keha ja meelt.' },
   { title: 'Kardio', description: 'Tõstab pulssi ja põletab kaloreid.' }
 ]
-
-const currentIndex = ref(0)
-const total = trainings.length
-
-function next() {
-  currentIndex.value = (currentIndex.value + 1) % total
-}
-
-function prev() {
-  currentIndex.value = (currentIndex.value - 1 + total) % total
-}
 </script>


### PR DESCRIPTION
## Summary
- create generic `Carousel` component with arrow controls
- refactor existing carousels to use the new component

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bda8f6073483308b2d0c4a847d3f1f