### PR TITLE
Consolidate carousel styling

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -119,12 +119,9 @@ body {
 }
 
 /* Carousel */
-.training-carousel,
-.other-training-carousel { position: relative; overflow: hidden; }
-.training-carousel .carousel-track,
-.other-training-carousel .carousel-track { display: flex; transition: transform 0.4s ease; }
-.training-carousel .training-card,
-.other-training-carousel .training-card { flex: 0 0 100%; }
+.training-carousel { position: relative; overflow: hidden; }
+.training-carousel .carousel-track { display: flex; transition: transform 0.4s ease; }
+.training-carousel .training-card { flex: 0 0 100%; }
 .carousel-arrow { position: absolute; top: 50%; transform: translateY(-50%); background: var(--brand); color: var(--brand-ink); border: none; border-radius: 50%; width: 44px; height: 44px; display: flex; align-items: center; justify-content: center; cursor: pointer; }
 .carousel-arrow.prev { left: 16px; }
 .carousel-arrow.next { right: 16px; }

--- a/src/components/OtherTrainingCarousel.vue
+++ b/src/components/OtherTrainingCarousel.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="section">
-    <Carousel class="other-training-carousel" :items="trainings">
+    <Carousel class="training-carousel" :items="trainings">
       <template #default="{ item }">
         <TrainingCard :training="item" />
       </template>


### PR DESCRIPTION
## Summary
- remove deprecated `other-training-carousel` styling
- standardize components on `training-carousel`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bda9f699848330a195e5e486702903