### PR TITLE
Hide carousel arrows and show placeholders when empty

### DIFF
--- a/src/components/Carousel.vue
+++ b/src/components/Carousel.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="carousel">
-    <button class="carousel-arrow prev" @click="prev" aria-label="Previous">
+    <button
+      v-if="showArrows"
+      class="carousel-arrow prev"
+      @click="prev"
+      aria-label="Previous"
+    >
       <span class="material-icons-round">chevron_left</span>
     </button>
     <div class="carousel-track" :style="{ transform: `translateX(-${currentIndex * 100}%)` }">
@@ -8,7 +13,12 @@
         <slot :item="item" :index="i" />
       </div>
     </div>
-    <button class="carousel-arrow next" @click="next" aria-label="Next">
+    <button
+      v-if="showArrows"
+      class="carousel-arrow next"
+      @click="next"
+      aria-label="Next"
+    >
       <span class="material-icons-round">chevron_right</span>
     </button>
   </div>
@@ -26,6 +36,7 @@ const props = defineProps({
 
 const currentIndex = ref(0)
 const total = computed(() => props.items.length)
+const showArrows = computed(() => props.items.length > 1)
 
 function next() {
   if (!total.value) return

--- a/src/components/NutritionVideosCarousel.vue
+++ b/src/components/NutritionVideosCarousel.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="section">
+  <section class="section" v-if="videos.length">
     <div class="card">
       <Carousel class="nutrition-videos-carousel" :items="videos">
         <template #default="{ item }">
@@ -10,6 +10,7 @@
       </Carousel>
     </div>
   </section>
+  <p v-else>Нет доступных видео.</p>
 </template>
 
 <script setup>

--- a/src/components/OtherTrainingCarousel.vue
+++ b/src/components/OtherTrainingCarousel.vue
@@ -1,11 +1,12 @@
 <template>
-  <section class="section">
+  <section class="section" v-if="trainings.length">
     <Carousel class="training-carousel" :items="trainings">
       <template #default="{ item }">
         <TrainingCard :training="item" />
       </template>
     </Carousel>
   </section>
+  <p v-else>Нет доступных тренировок.</p>
 </template>
 
 <script setup>

--- a/src/components/TrainingCarousel.vue
+++ b/src/components/TrainingCarousel.vue
@@ -1,11 +1,12 @@
 <template>
-  <section class="section">
+  <section class="section" v-if="trainings.length">
     <Carousel class="training-carousel" :items="trainings">
       <template #default="{ item }">
         <TrainingCard :training="item" />
       </template>
     </Carousel>
   </section>
+  <p v-else>Нет доступных тренировок.</p>
 </template>
 
 <script setup>


### PR DESCRIPTION
## Summary
- Compute `showArrows` in base Carousel to show navigation only when more than one item
- Display messages when carousels have no items

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdaaac67f083308ba869517a0bc8ee