### PR TITLE
Refactor services section to use dynamic list

### DIFF
--- a/src/components/ServicesSection.vue
+++ b/src/components/ServicesSection.vue
@@ -2,21 +2,31 @@
   <section id="services" class="section">
     <h2>Teenused</h2>
     <div class="cards">
-      <article class="card">
-        <h3>Personaaltrenn</h3>
-        <p>Ühele inimesele kohandatud treeningkava ja tugi.</p>
-      </article>
-      <article class="card">
-        <h3>Rühmatrennid</h3>
-        <p>Motiveeriv treening väikestes gruppides.</p>
-      </article>
-      <article class="card">
-        <h3>Toitumisnõustamine</h3>
-        <p>Lihtsad sammud paremate toitumisharjumusteni.</p>
+      <article
+        v-for="service in services"
+        :key="service.title"
+        class="card"
+      >
+        <h3>{{ service.title }}</h3>
+        <p>{{ service.description }}</p>
       </article>
     </div>
   </section>
 </template>
 
 <script setup>
+const services = [
+  {
+    title: 'Personaaltrenn',
+    description: 'Ühele inimesele kohandatud treeningkava ja tugi.'
+  },
+  {
+    title: 'Rühmatrennid',
+    description: 'Motiveeriv treening väikestes gruppides.'
+  },
+  {
+    title: 'Toitumisnõustamine',
+    description: 'Lihtsad sammud paremate toitumisharjumusteni.'
+  }
+]
 </script>


### PR DESCRIPTION
## Summary
- Use an array in `<script setup>` to define services
- Render services with `v-for` instead of static markup

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdac0c6a8483309988c35ecd15530f