### PR TITLE
Fix PWA start_url to root

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MinuTrenn",
   "short_name": "Trenn",
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#0076ff",


### PR DESCRIPTION
## Summary
- change PWA manifest start_url to use '/' instead of '.'

## Testing
- `npm run build`
- `npm run preview >/tmp/preview.log 2>&1 </dev/null &`; `curl -s http://localhost:4173/manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_68bdac79bbd48330bdf61f65f04f01a1