### PR TITLE
fix: support subdirectory deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
     <meta name="theme-color" content="#0076ff" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <link rel="manifest" href="/manifest.json" />
-    <link rel="icon" href="/img/icon-192.png" />
-    <link rel="apple-touch-icon" href="/img/icon-192.png" />
+    <link rel="manifest" href="./manifest.json" />
+    <link rel="icon" href="./img/icon-192.png" />
+    <link rel="apple-touch-icon" href="./img/icon-192.png" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Icons+Round" />
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "MinuTrenn",
   "short_name": "Trenn",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#0076ff",

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,10 +1,10 @@
 const CACHE = 'minutrenn-v2';
 const ASSETS = [
-  '/index.html',
-  '/manifest.json',
-  '/img/icon-192.png',
-  '/img/icon-512.png',
-  '/img/hero.jpg'
+  './index.html',
+  './manifest.json',
+  './img/icon-192.png',
+  './img/icon-512.png',
+  './img/hero.jpg'
 ];
 
 self.addEventListener('install', event => {
@@ -27,7 +27,7 @@ self.addEventListener('fetch', event => {
   // Network-first strategy for navigation requests to avoid serving stale HTML
   if (request.mode === 'navigate') {
     event.respondWith(
-      fetch(request).catch(() => caches.match('/index.html'))
+      fetch(request).catch(() => caches.match('./index.html'))
     );
     return;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,8 @@ window.addEventListener('load', () => {
   if (preloader) preloader.remove()
 
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/service-worker.js', { scope: '/' })
+    navigator.serviceWorker
+      .register(`${import.meta.env.BASE_URL}service-worker.js`, { scope: import.meta.env.BASE_URL })
       .then(() => console.log('Service Worker registered'))
       .catch(err => console.error('SW registration failed:', err))
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
+  base: './',
   plugins: [vue()]
 })


### PR DESCRIPTION
## Summary
- make asset and service worker paths relative so build works from subdirectories
- register service worker using Vite base path
- configure Vite base for relative deployments

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bdb0474eec8330945a571e56b83f63