### PR TITLE
Setup GitHub Pages build and deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,8 @@
 {
   "name": "MinuTrenn",
   "short_name": "Trenn",
-  "start_url": "./",
+  "start_url": "/Site/",
+  "scope": "/Site/",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#0076ff",

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -68,7 +68,8 @@ body {
 
 /* Hero */
 .hero {
-  background: url("/img/hero.jpg") center / cover no-repeat, linear-gradient(160deg, #0c0c0c, #242424);
+  /* Absolute URLs must include the /Site/ prefix for GitHub Pages */
+  background: url("/Site/img/hero.jpg") center / cover no-repeat, linear-gradient(160deg, #0c0c0c, #242424);
   color: white;
   min-height: 60vh;
   display: grid;

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
-  base: './',
+  // GitHub Pages serves this site from https://<user>.github.io/Site/
+  // so all asset URLs must be prefixed with /Site/
+  base: '/Site/',
   plugins: [vue()]
 })


### PR DESCRIPTION
## Summary
- configure Vite to build with `/Site/` base and copy index to 404 for SPA routing
- adjust manifest and assets for PWA and correct GitHub Pages paths
- add GitHub Actions workflow to build and deploy `dist` to GitHub Pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdb659929883309caa9f5a4bd594d2