### PR TITLE
Load Vue from CDN for static deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,15 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Icons+Round" />
   </head>
   <body>
-    <div id="app"></div>
-    <script type="module" src="./src/main.js"></script>
+    <div id="app">{{ message }}</div>
+    <script type="module">
+      import { createApp } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
+
+      createApp({
+        data() {
+          return { message: 'Hello Vue!' }
+        }
+      }).mount('#app')
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Vue 3 from the unpkg CDN directly in `index.html` for environments without a bundler.
- Mount a minimal Vue application inline, displaying a sample message.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdc12e2e708330a2a73b153bb27a48