### PR TITLE
refactor: use Vite entrypoint in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,15 +14,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Icons+Round" />
   </head>
   <body>
-    <div id="app">{{ message }}</div>
-    <script type="module">
-      import { createApp } from 'https://unpkg.com/vue@3/dist/vue.esm-browser.js'
-
-      createApp({
-        data() {
-          return { message: 'Hello Vue!' }
-        }
-      }).mount('#app')
-    </script>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove inline CDN Vue block
- add Vite script entry and clean `#app` container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdcaa0a4748330b1357b51454debdd